### PR TITLE
handle the default datatype as no occurrence

### DIFF
--- a/src/main/resources/SchemaForGrammars.xsd
+++ b/src/main/resources/SchemaForGrammars.xsd
@@ -242,7 +242,8 @@
                             <xs:element name="attributeNamespaceID" type="xs:unsignedInt"/>
                             <xs:element name="attributeLocalNameID" type="xs:unsignedInt"/>
                             <!-- attribute datatype -->
-                            <xs:element name="attributeDatatypeID" type="xs:unsignedInt"/>
+                            <xs:element name="attributeDatatypeID" type="xs:unsignedInt"
+                                minOccurs="0"/>
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>


### PR DESCRIPTION
The default datatype is not added to the listOfSimpleDatatypes, so in a example it was serialized as -1 (the result of indexOf), so I changed the datatypeID elements to have a minOccurs of 0 and a lack of occurrence means the default datatype. I didn't changed the logic for the globalComplexTypeGrammarID or globalAttributeDatatypeID. I am not exactly sure about them.