### PR TITLE
fix and add tests

### DIFF
--- a/src/test/java/com/siemens/ct/exi/grammars/persistency/Grammars2XTest.java
+++ b/src/test/java/com/siemens/ct/exi/grammars/persistency/Grammars2XTest.java
@@ -1,22 +1,7 @@
 package com.siemens.ct.exi.grammars.persistency;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-
-import javax.xml.transform.Result;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.sax.SAXSource;
-import javax.xml.transform.stream.StreamResult;
-
-import junit.framework.TestCase;
-
-import org.junit.Test;
-import org.xml.sax.InputSource;
-import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
-
 import com.siemens.ct.exi.EXIFactory;
+import com.siemens.ct.exi.FidelityOptions;
 import com.siemens.ct.exi._2017.schemaforgrammars.ExiGrammars;
 import com.siemens.ct.exi.api.sax.EXIResult;
 import com.siemens.ct.exi.api.sax.EXISource;
@@ -24,6 +9,21 @@ import com.siemens.ct.exi.exceptions.EXIException;
 import com.siemens.ct.exi.grammars.SchemaInformedGrammars;
 import com.siemens.ct.exi.grammars.XSDGrammarsBuilder;
 import com.siemens.ct.exi.helpers.DefaultEXIFactory;
+import junit.framework.TestCase;
+import org.custommonkey.xmlunit.XMLAssert;
+import org.junit.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLReaderFactory;
+
+import javax.xml.transform.Result;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
 
 public class Grammars2XTest extends TestCase {
 	
@@ -50,6 +50,7 @@ public class Grammars2XTest extends TestCase {
 		
 		// try to encode with original Grammars and to decode with transformed Grammars
 		EXIFactory exiFactory = DefaultEXIFactory.newInstance();
+        exiFactory.setFidelityOptions(FidelityOptions.createAll());
 		// 1. Encode
 		exiFactory.setGrammars(grammarsIn);
 		
@@ -58,7 +59,8 @@ public class Grammars2XTest extends TestCase {
 		exiResult.setOutputStream(osEXI);
 		XMLReader xmlReader = XMLReaderFactory.createXMLReader();
 		xmlReader.setContentHandler( exiResult.getHandler() );
-		xmlReader.parse(xml); // parse XML input
+        InputSource isXML = new InputSource(xml);
+		xmlReader.parse(isXML); // parse XML input
 		osEXI.close();
 		
 		// 2. Decode
@@ -70,12 +72,15 @@ public class Grammars2XTest extends TestCase {
 		TransformerFactory tf = TransformerFactory.newInstance();
 		Transformer transformer = tf.newTransformer();
 		transformer.transform(exiSource, result);
-	}
+        String xmlOut = osXML.toString();
+        InputSource isXMLOut = new InputSource(new StringReader(xmlOut));
+        XMLAssert.assertXMLEqual(isXML, isXMLOut);
+    }
 
 	@Test
 	public void testNotebook() throws Exception {
 		String xsd = "data/W3C/PrimerNotebook/notebook.xsd";
-		String xml = "data/W3C/PrimerNotebook/notebook.xsd";
+		String xml = "data/W3C/PrimerNotebook/notebook.xml";
 		_test(xsd, xml);
 	}
 	
@@ -96,8 +101,35 @@ public class Grammars2XTest extends TestCase {
 	@Test
 	public void testDatatypes() throws Exception {
 		String xsd = "data/general/datatypes.xsd";
-		String xml = "data/general/datatypes.xsd";
+		String xml = "data/general/datatypes.xml";
 		_test(xsd, xml);
 	}
 
+    protected void testRoundTripExiGrammarsXml(String xsd) throws Exception {
+		grammarBuilder.loadGrammars(xsd);
+		SchemaInformedGrammars grammarsIn = grammarBuilder.toGrammars();
+
+        Grammars2X grammars2X = new Grammars2X();
+        ExiGrammars exiGrammars = grammars2X.toGrammarsX(grammarsIn);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Grammars2X.marshall(exiGrammars, baos);
+        String exiGrammarsXml = baos.toString();
+
+        ExiGrammars exiGrammarOut = Grammars2X.unmarshall(new ByteArrayInputStream(baos.toByteArray()));
+        SchemaInformedGrammars grammarsOut = Grammars2X.toGrammars(exiGrammarOut);
+
+        grammars2X.clear();
+        ExiGrammars exiGrammarsRoundTrip = grammars2X.toGrammarsX(grammarsOut);
+        ByteArrayOutputStream baosRoundTrip = new ByteArrayOutputStream();
+        Grammars2X.marshall(exiGrammarsRoundTrip, baosRoundTrip);
+        String exiGrammarsXmlRoundTrip = baosRoundTrip.toString();
+
+        XMLAssert.assertXMLEqual(exiGrammarsXml, exiGrammarsXmlRoundTrip);
+	}
+
+    @Test
+    public void testRoundTripExiGrammarsXmlNotebook() throws Exception {
+        testRoundTripExiGrammarsXml("data/W3C/PrimerNotebook/notebook.xsd");
+    }
 }


### PR DESCRIPTION
test the Xml with the round trip result
fix the xml file paths of the tests
add a test that verify a round trip of ExiGrammars Xml are the same (this fails for now), I think it is related to the line :
750 in Grammars2X, where only next Grammar with non zero number of events are added