### PR TITLE
Bump xerces to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>xerces</groupId>
 			<artifactId>xercesImpl</artifactId>
-			<version>2.11.0</version>
+			<version>2.12.0</version>
 		</dependency>
 		<!-- Test Dependencies -->
 		<dependency>

--- a/src/test/java/com/siemens/ct/exi/grammars/persistency/Grammars2JavaSourceCodeTest.java
+++ b/src/test/java/com/siemens/ct/exi/grammars/persistency/Grammars2JavaSourceCodeTest.java
@@ -22,6 +22,8 @@ public class Grammars2JavaSourceCodeTest extends TestCase {
 	static String WORKSPACE_DIR = System.getProperty("workspace");
 	static String FILE_SEPARATOR = System.getProperty("file.separator");
 	static String OS = System.getProperty("os.name").toLowerCase();
+	
+	static final String EXIFICIENT_CORE_JAR = "/.m2/repository/com/siemens/ct/exi/exificient-core/1.0.2-SNAPSHOT/exificient-core-1.0.2-SNAPSHOT.jar";
 
 	XSDGrammarsBuilder grammarBuilder = XSDGrammarsBuilder.newInstance();
 
@@ -86,8 +88,7 @@ public class Grammars2JavaSourceCodeTest extends TestCase {
 	static String getEXIficientCoreJar() {
 		// String url =
 		// "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.siemens.ct.exi&a=exificient-core&v=LATEST";
-		final String DEFAULT_EXIFICIENT_CORE_JAR = USER_HOME
-				+ "/.m2/repository/com/siemens/ct/exi/exificient-core/1.0.0-SNAPSHOT/exificient-core-1.0.0-SNAPSHOT.jar";
+		final String DEFAULT_EXIFICIENT_CORE_JAR = USER_HOME + EXIFICIENT_CORE_JAR;
 
 		return DEFAULT_EXIFICIENT_CORE_JAR;
 	}


### PR DESCRIPTION
This bumps the xerces dependency version to 2.12.0 to pick up the fixes detailed in https://www.xml.com/news/2018-05-apache-xerces-j-2120/