### PR TITLE
Test for Java assertion

### DIFF
--- a/src/test/java/com/siemens/ct/exi/grammars/GrammarXSFTest.java
+++ b/src/test/java/com/siemens/ct/exi/grammars/GrammarXSFTest.java
@@ -1,0 +1,126 @@
+package com.siemens.ct.exi.grammars;
+
+import org.apache.xerces.xni.XMLResourceIdentifier;
+import org.apache.xerces.xni.XNIException;
+import org.apache.xerces.xni.parser.XMLEntityResolver;
+import org.apache.xerces.xni.parser.XMLInputSource;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+import static org.junit.Assert.fail;
+
+/**
+ * A test that verifies if a Java assertion is thrown when creating grammar from a set of XSDs.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class GrammarXSFTest
+{
+    @Before
+    public void beforeMethod() {
+        // For this test to be useful, assertions needs to be enabled (run this test with the '-ea' flag)
+        Assume.assumeTrue(EXIContentModelBuilder.class.desiredAssertionStatus());
+    }
+
+    /**
+     * Tests if creating grammars from an XSD causes a Java assertion to be thrown.
+     */
+    @Test
+    public void testAssertionNotThrown() throws Exception
+    {
+        // Setup test fixture.
+        final File defaultSchema = new File("src/test/resources/xsf/defaultSchema.xsd");
+        if (!defaultSchema.exists()) {
+            throw new IllegalStateException("Unit test implementation has a bug.");
+        }
+
+        final GrammarFactory grammarFactory = GrammarFactory.newInstance();
+        final String xsdLocation = defaultSchema.getAbsolutePath();
+        final XMLEntityResolver xmlEntityResolverResolver = new SchemaResolver();
+
+        // Execute system under test.
+        try
+        {
+            grammarFactory.createGrammars(xsdLocation, xmlEntityResolverResolver);
+        }
+        catch (AssertionError e)
+        {
+            // Verify results.
+            e.printStackTrace();
+            fail("Java assertion was thrown (stacktrace was printed on the standard error stream).");
+        }
+    }
+
+    /**
+     * Resolves entities from XSD files provided as part in the test resources.
+     */
+    public static class SchemaResolver implements XMLEntityResolver
+    {
+        private final HashMap<String, String> namespaceToPath;
+
+        public SchemaResolver() throws ParserConfigurationException, IOException, SAXException
+        {
+            namespaceToPath = new HashMap<String, String>();
+
+            // Iterate over all files to record a namespace-to-path mapping.
+            final File folder = new File("src/test/resources/xsf/");
+            if (!folder.isDirectory()) {
+                throw new IllegalStateException("Unit test implementation has a bug.");
+            }
+            final File[] listOfFiles = folder.listFiles();
+            if (listOfFiles == null) {
+                throw new IllegalStateException("Unit test implementation has a bug.");
+            }
+
+            final DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+
+            for (final File file : listOfFiles) {
+                if (file.isFile() && file.getName().endsWith(".xsd")) {
+                    final String fileLocation = file.getAbsolutePath();
+
+                    final Document doc = builder.parse(file);
+                    doc.getDocumentElement().normalize();
+                    final String namespace = doc.getDocumentElement().getAttribute("targetNamespace");
+
+                    System.out.println("Found namespace '" + namespace + "' in file: " + fileLocation);
+                    this.namespaceToPath.put(namespace, file.getCanonicalPath());
+                }
+            }
+
+//            // Add DTDs
+//            this.namespaceToPath.put("-//W3C//DTD XMLSCHEMA 200102//EN", new File("src/test/resources/XMLSchema.dtd").getAbsolutePath());
+//            this.namespaceToPath.put("datatypes", new File("src/test/resources/datatypes.dtd").getAbsolutePath());
+        }
+
+        public XMLInputSource resolveEntity(XMLResourceIdentifier resourceIdentifier) throws XNIException, IOException
+        {
+            String needle = resourceIdentifier.getNamespace();
+            if (needle == null) {
+                needle = resourceIdentifier.getPublicId();
+            }
+            XMLInputSource result = null;
+            if (needle != null) {
+                if (this.namespaceToPath.containsKey(needle)) {
+                    String location = this.namespaceToPath.get(needle);
+                    result = new XMLInputSource(resourceIdentifier.getPublicId(), location, resourceIdentifier.getBaseSystemId());
+                    System.out.println("Resolved namespace: '" + needle + "' to: " + result.getSystemId());
+                } else {
+                    System.err.println("Unable to resolved namespace: '" + needle + "'");
+                }
+            } else {
+                System.out.println("Skipping no-namespace lookup for resource identifier: " + resourceIdentifier);
+            }
+            return result;
+        }
+    }
+}

--- a/src/test/resources/xsf/XMLSchema.dtd
+++ b/src/test/resources/xsf/XMLSchema.dtd
@@ -1,0 +1,402 @@
+<!-- DTD for XML Schemas: Part 1: Structures
+     Public Identifier: "-//W3C//DTD XMLSCHEMA 200102//EN"
+     Official Location: http://www.w3.org/2001/XMLSchema.dtd -->
+<!-- $Id: XMLSchema.dtd,v 1.31 2001/10/24 15:50:16 ht Exp $ -->
+<!-- Note this DTD is NOT normative, or even definitive. -->           <!--d-->
+<!-- prose copy in the structures REC is the definitive version -->    <!--d-->
+<!-- (which shouldn't differ from this one except for this -->         <!--d-->
+<!-- comment and entity expansions, but just in case) -->              <!--d-->
+<!-- With the exception of cases with multiple namespace
+     prefixes for the XML Schema namespace, any XML document which is
+     not valid per this DTD given redefinitions in its internal subset of the
+     'p' and 's' parameter entities below appropriate to its namespace
+     declaration of the XML Schema namespace is almost certainly not
+     a valid schema. -->
+
+<!-- The simpleType element and its constituent parts
+     are defined in XML Schema: Part 2: Datatypes -->
+<!ENTITY % xs-datatypes PUBLIC 'datatypes' 'datatypes.dtd' >
+
+<!ENTITY % p 'xs:'> <!-- can be overriden in the internal subset of a
+                         schema document to establish a different
+                         namespace prefix -->
+<!ENTITY % s ':xs'> <!-- if %p is defined (e.g. as foo:) then you must
+                         also define %s as the suffix for the appropriate
+                         namespace declaration (e.g. :foo) -->
+<!ENTITY % nds 'xmlns%s;'>
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % schema "%p;schema">
+<!ENTITY % complexType "%p;complexType">
+<!ENTITY % complexContent "%p;complexContent">
+<!ENTITY % simpleContent "%p;simpleContent">
+<!ENTITY % extension "%p;extension">
+<!ENTITY % element "%p;element">
+<!ENTITY % unique "%p;unique">
+<!ENTITY % key "%p;key">
+<!ENTITY % keyref "%p;keyref">
+<!ENTITY % selector "%p;selector">
+<!ENTITY % field "%p;field">
+<!ENTITY % group "%p;group">
+<!ENTITY % all "%p;all">
+<!ENTITY % choice "%p;choice">
+<!ENTITY % sequence "%p;sequence">
+<!ENTITY % any "%p;any">
+<!ENTITY % anyAttribute "%p;anyAttribute">
+<!ENTITY % attribute "%p;attribute">
+<!ENTITY % attributeGroup "%p;attributeGroup">
+<!ENTITY % include "%p;include">
+<!ENTITY % import "%p;import">
+<!ENTITY % redefine "%p;redefine">
+<!ENTITY % notation "%p;notation">
+
+<!-- annotation elements -->
+<!ENTITY % annotation "%p;annotation">
+<!ENTITY % appinfo "%p;appinfo">
+<!ENTITY % documentation "%p;documentation">
+
+<!-- Customisation entities for the ATTLIST of each element type.
+     Define one of these if your schema takes advantage of the
+     anyAttribute='##other' in the schema for schemas -->
+
+<!ENTITY % schemaAttrs ''>
+<!ENTITY % complexTypeAttrs ''>
+<!ENTITY % complexContentAttrs ''>
+<!ENTITY % simpleContentAttrs ''>
+<!ENTITY % extensionAttrs ''>
+<!ENTITY % elementAttrs ''>
+<!ENTITY % groupAttrs ''>
+<!ENTITY % allAttrs ''>
+<!ENTITY % choiceAttrs ''>
+<!ENTITY % sequenceAttrs ''>
+<!ENTITY % anyAttrs ''>
+<!ENTITY % anyAttributeAttrs ''>
+<!ENTITY % attributeAttrs ''>
+<!ENTITY % attributeGroupAttrs ''>
+<!ENTITY % uniqueAttrs ''>
+<!ENTITY % keyAttrs ''>
+<!ENTITY % keyrefAttrs ''>
+<!ENTITY % selectorAttrs ''>
+<!ENTITY % fieldAttrs ''>
+<!ENTITY % includeAttrs ''>
+<!ENTITY % importAttrs ''>
+<!ENTITY % redefineAttrs ''>
+<!ENTITY % notationAttrs ''>
+<!ENTITY % annotationAttrs ''>
+<!ENTITY % appinfoAttrs ''>
+<!ENTITY % documentationAttrs ''>
+
+<!ENTITY % complexDerivationSet "CDATA">
+      <!-- #all or space-separated list drawn from derivationChoice -->
+<!ENTITY % blockSet "CDATA">
+      <!-- #all or space-separated list drawn from
+                      derivationChoice + 'substitution' -->
+
+<!ENTITY % mgs '%all; | %choice; | %sequence;'>
+<!ENTITY % cs '%choice; | %sequence;'>
+<!ENTITY % formValues '(qualified|unqualified)'>
+
+
+<!ENTITY % attrDecls    '((%attribute;| %attributeGroup;)*,(%anyAttribute;)?)'>
+
+<!ENTITY % particleAndAttrs '((%mgs; | %group;)?, %attrDecls;)'>
+
+<!-- This is used in part2 -->
+<!ENTITY % restriction1 '((%mgs; | %group;)?)'>
+
+%xs-datatypes;
+
+<!-- the duplication below is to produce an unambiguous content model
+     which allows annotation everywhere -->
+<!ELEMENT %schema; ((%include; | %import; | %redefine; | %annotation;)*,
+                    ((%simpleType; | %complexType;
+                      | %element; | %attribute;
+                      | %attributeGroup; | %group;
+                      | %notation; ),
+                     (%annotation;)*)* )>
+<!ATTLIST %schema;
+   targetNamespace      %URIref;               #IMPLIED
+   version              CDATA                  #IMPLIED
+   %nds;                %URIref;               #FIXED 'http://www.w3.org/2001/XMLSchema'
+   xmlns                CDATA                  #IMPLIED
+   finalDefault         %complexDerivationSet; ''
+   blockDefault         %blockSet;             ''
+   id                   ID                     #IMPLIED
+   elementFormDefault   %formValues;           'unqualified'
+   attributeFormDefault %formValues;           'unqualified'
+   xml:lang             CDATA                  #IMPLIED
+   %schemaAttrs;>
+<!-- Note the xmlns declaration is NOT in the Schema for Schemas,
+     because at the Infoset level where schemas operate,
+     xmlns(:prefix) is NOT an attribute! -->
+<!-- The declaration of xmlns is a convenience for schema authors -->
+ 
+<!-- The id attribute here and below is for use in external references
+     from non-schemas using simple fragment identifiers.
+     It is NOT used for schema-to-schema reference, internal or
+     external. -->
+
+<!-- a type is a named content type specification which allows attribute
+     declarations-->
+<!-- -->
+
+<!ELEMENT %complexType; ((%annotation;)?,
+                         (%simpleContent;|%complexContent;|
+                          %particleAndAttrs;))>
+
+<!ATTLIST %complexType;
+          name      %NCName;                        #IMPLIED
+          id        ID                              #IMPLIED
+          abstract  %boolean;                       #IMPLIED
+          final     %complexDerivationSet;          #IMPLIED
+          block     %complexDerivationSet;          #IMPLIED
+          mixed (true|false) 'false'
+          %complexTypeAttrs;>
+
+<!-- particleAndAttrs is shorthand for a root type -->
+<!-- mixed is disallowed if simpleContent, overriden if complexContent
+     has one too. -->
+
+<!-- If anyAttribute appears in one or more referenced attributeGroups
+     and/or explicitly, the intersection of the permissions is used -->
+
+<!ELEMENT %complexContent; ((%annotation;)?, (%restriction;|%extension;))>
+<!ATTLIST %complexContent;
+          mixed (true|false) #IMPLIED
+          id    ID           #IMPLIED
+          %complexContentAttrs;>
+
+<!-- restriction should use the branch defined above, not the simple
+     one from part2; extension should use the full model  -->
+
+<!ELEMENT %simpleContent; ((%annotation;)?, (%restriction;|%extension;))>
+<!ATTLIST %simpleContent;
+          id    ID           #IMPLIED
+          %simpleContentAttrs;>
+
+<!-- restriction should use the simple branch from part2, not the 
+     one defined above; extension should have no particle  -->
+
+<!ELEMENT %extension; ((%annotation;)?, (%particleAndAttrs;))>
+<!ATTLIST %extension;
+          base  %QName;      #REQUIRED
+          id    ID           #IMPLIED
+          %extensionAttrs;>
+
+<!-- an element is declared by either:
+ a name and a type (either nested or referenced via the type attribute)
+ or a ref to an existing element declaration -->
+
+<!ELEMENT %element; ((%annotation;)?, (%complexType;| %simpleType;)?,
+                     (%unique; | %key; | %keyref;)*)>
+<!-- simpleType or complexType only if no type|ref attribute -->
+<!-- ref not allowed at top level -->
+<!ATTLIST %element;
+            name               %NCName;               #IMPLIED
+            id                 ID                     #IMPLIED
+            ref                %QName;                #IMPLIED
+            type               %QName;                #IMPLIED
+            minOccurs          %nonNegativeInteger;   #IMPLIED
+            maxOccurs          CDATA                  #IMPLIED
+            nillable           %boolean;              #IMPLIED
+            substitutionGroup  %QName;                #IMPLIED
+            abstract           %boolean;              #IMPLIED
+            final              %complexDerivationSet; #IMPLIED
+            block              %blockSet;             #IMPLIED
+            default            CDATA                  #IMPLIED
+            fixed              CDATA                  #IMPLIED
+            form               %formValues;           #IMPLIED
+            %elementAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- In the absence of type AND ref, type defaults to type of
+     substitutionGroup, if any, else the ur-type, i.e. unconstrained -->
+<!-- default and fixed are mutually exclusive -->
+
+<!ELEMENT %group; ((%annotation;)?,(%mgs;)?)>
+<!ATTLIST %group; 
+          name        %NCName;               #IMPLIED
+          ref         %QName;                #IMPLIED
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %groupAttrs;>
+
+<!ELEMENT %all; ((%annotation;)?, (%element;)*)>
+<!ATTLIST %all;
+          minOccurs   (1)                    #IMPLIED
+          maxOccurs   (1)                    #IMPLIED
+          id          ID                     #IMPLIED
+          %allAttrs;>
+
+<!ELEMENT %choice; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %choice;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %choiceAttrs;>
+
+<!ELEMENT %sequence; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %sequence;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %sequenceAttrs;>
+
+<!-- an anonymous grouping in a model, or
+     a top-level named group definition, or a reference to same -->
+
+<!-- Note that if order is 'all', group is not allowed inside.
+     If order is 'all' THIS group must be alone (or referenced alone) at
+     the top level of a content model -->
+<!-- If order is 'all', minOccurs==maxOccurs==1 on element/any inside -->
+<!-- Should allow minOccurs=0 inside order='all' . . . -->
+
+<!ELEMENT %any; (%annotation;)?>
+<!ATTLIST %any;
+            namespace       CDATA                  '##any'
+            processContents (skip|lax|strict)      'strict'
+            minOccurs       %nonNegativeInteger;   '1'
+            maxOccurs       CDATA                  '1'
+            id              ID                     #IMPLIED
+            %anyAttrs;>
+
+<!-- namespace is interpreted as follows:
+                  ##any      - - any non-conflicting WFXML at all
+
+                  ##other    - - any non-conflicting WFXML from namespace other
+                                  than targetNamespace
+
+                  ##local    - - any unqualified non-conflicting WFXML/attribute
+                  one or     - - any non-conflicting WFXML from
+                  more URI        the listed namespaces
+                  references
+
+                  ##targetNamespace ##local may appear in the above list,
+                    with the obvious meaning -->
+
+<!ELEMENT %anyAttribute; (%annotation;)?>
+<!ATTLIST %anyAttribute;
+            namespace       CDATA              '##any'
+            processContents (skip|lax|strict)  'strict'
+            id              ID                 #IMPLIED
+            %anyAttributeAttrs;>
+<!-- namespace is interpreted as for 'any' above -->
+
+<!-- simpleType only if no type|ref attribute -->
+<!-- ref not allowed at top level, name iff at top level -->
+<!ELEMENT %attribute; ((%annotation;)?, (%simpleType;)?)>
+<!ATTLIST %attribute;
+          name      %NCName;      #IMPLIED
+          id        ID            #IMPLIED
+          ref       %QName;       #IMPLIED
+          type      %QName;       #IMPLIED
+          use       (prohibited|optional|required) #IMPLIED
+          default   CDATA         #IMPLIED
+          fixed     CDATA         #IMPLIED
+          form      %formValues;  #IMPLIED
+          %attributeAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- default for use is optional when nested, none otherwise -->
+<!-- default and fixed are mutually exclusive -->
+<!-- type attr and simpleType content are mutually exclusive -->
+
+<!-- an attributeGroup is a named collection of attribute decls, or a
+     reference thereto -->
+<!ELEMENT %attributeGroup; ((%annotation;)?,
+                       (%attribute; | %attributeGroup;)*,
+                       (%anyAttribute;)?) >
+<!ATTLIST %attributeGroup;
+                 name       %NCName;       #IMPLIED
+                 id         ID             #IMPLIED
+                 ref        %QName;        #IMPLIED
+                 %attributeGroupAttrs;>
+
+<!-- ref iff no content, no name.  ref iff not top level -->
+
+<!-- better reference mechanisms -->
+<!ELEMENT %unique; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %unique;
+          name     %NCName;       #REQUIRED
+	  id       ID             #IMPLIED
+	  %uniqueAttrs;>
+
+<!ELEMENT %key;    ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %key;
+          name     %NCName;       #REQUIRED
+	  id       ID             #IMPLIED
+	  %keyAttrs;>
+
+<!ELEMENT %keyref; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %keyref;
+          name     %NCName;       #REQUIRED
+	  refer    %QName;        #REQUIRED
+	  id       ID             #IMPLIED
+	  %keyrefAttrs;>
+
+<!ELEMENT %selector; ((%annotation;)?)>
+<!ATTLIST %selector;
+          xpath %XPathExpr; #REQUIRED
+          id    ID          #IMPLIED
+          %selectorAttrs;>
+<!ELEMENT %field; ((%annotation;)?)>
+<!ATTLIST %field;
+          xpath %XPathExpr; #REQUIRED
+          id    ID          #IMPLIED
+          %fieldAttrs;>
+
+<!-- Schema combination mechanisms -->
+<!ELEMENT %include; (%annotation;)?>
+<!ATTLIST %include;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %includeAttrs;>
+
+<!ELEMENT %import; (%annotation;)?>
+<!ATTLIST %import;
+          namespace      %URIref; #IMPLIED
+          schemaLocation %URIref; #IMPLIED
+          id             ID       #IMPLIED
+          %importAttrs;>
+
+<!ELEMENT %redefine; (%annotation; | %simpleType; | %complexType; |
+                      %attributeGroup; | %group;)*>
+<!ATTLIST %redefine;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %redefineAttrs;>
+
+<!ELEMENT %notation; (%annotation;)?>
+<!ATTLIST %notation;
+	  name        %NCName;    #REQUIRED
+	  id          ID          #IMPLIED
+	  public      CDATA       #REQUIRED
+	  system      %URIref;    #IMPLIED
+	  %notationAttrs;>
+
+<!-- Annotation is either application information or documentation -->
+<!-- By having these here they are available for datatypes as well
+     as all the structures elements -->
+
+<!ELEMENT %annotation; (%appinfo; | %documentation;)*>
+<!ATTLIST %annotation; %annotationAttrs;>
+
+<!-- User must define annotation elements in internal subset for this
+     to work -->
+<!ELEMENT %appinfo; ANY>   <!-- too restrictive -->
+<!ATTLIST %appinfo;
+          source     %URIref;      #IMPLIED
+          id         ID         #IMPLIED
+          %appinfoAttrs;>
+<!ELEMENT %documentation; ANY>   <!-- too restrictive -->
+<!ATTLIST %documentation;
+          source     %URIref;   #IMPLIED
+          id         ID         #IMPLIED
+          xml:lang   CDATA      #IMPLIED
+          %documentationAttrs;>
+
+<!NOTATION XMLSchemaStructures PUBLIC
+           'structures' 'http://www.w3.org/2001/XMLSchema.xsd' >
+<!NOTATION XML PUBLIC
+           'REC-xml-1998-0210' 'http://www.w3.org/TR/1998/REC-xml-19980210' >

--- a/src/test/resources/xsf/datatypes.dtd
+++ b/src/test/resources/xsf/datatypes.dtd
@@ -1,0 +1,203 @@
+<!--
+        DTD for XML Schemas: Part 2: Datatypes
+        $Id: datatypes.dtd,v 1.23 2001/03/16 17:36:30 ht Exp $
+        Note this DTD is NOT normative, or even definitive. - - the
+        prose copy in the datatypes REC is the definitive version
+        (which shouldn't differ from this one except for this comment
+        and entity expansions, but just in case)
+  -->
+
+<!--
+        This DTD cannot be used on its own, it is intended
+        only for incorporation in XMLSchema.dtd, q.v.
+  -->
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % simpleType "%p;simpleType">
+<!ENTITY % restriction "%p;restriction">
+<!ENTITY % list "%p;list">
+<!ENTITY % union "%p;union">
+<!ENTITY % maxExclusive "%p;maxExclusive">
+<!ENTITY % minExclusive "%p;minExclusive">
+<!ENTITY % maxInclusive "%p;maxInclusive">
+<!ENTITY % minInclusive "%p;minInclusive">
+<!ENTITY % totalDigits "%p;totalDigits">
+<!ENTITY % fractionDigits "%p;fractionDigits">
+<!ENTITY % length "%p;length">
+<!ENTITY % minLength "%p;minLength">
+<!ENTITY % maxLength "%p;maxLength">
+<!ENTITY % enumeration "%p;enumeration">
+<!ENTITY % whiteSpace "%p;whiteSpace">
+<!ENTITY % pattern "%p;pattern">
+
+<!--
+        Customisation entities for the ATTLIST of each element
+        type. Define one of these if your schema takes advantage
+        of the anyAttribute='##other' in the schema for schemas
+  -->
+
+<!ENTITY % simpleTypeAttrs "">
+<!ENTITY % restrictionAttrs "">
+<!ENTITY % listAttrs "">
+<!ENTITY % unionAttrs "">
+<!ENTITY % maxExclusiveAttrs "">
+<!ENTITY % minExclusiveAttrs "">
+<!ENTITY % maxInclusiveAttrs "">
+<!ENTITY % minInclusiveAttrs "">
+<!ENTITY % totalDigitsAttrs "">
+<!ENTITY % fractionDigitsAttrs "">
+<!ENTITY % lengthAttrs "">
+<!ENTITY % minLengthAttrs "">
+<!ENTITY % maxLengthAttrs "">
+<!ENTITY % enumerationAttrs "">
+<!ENTITY % whiteSpaceAttrs "">
+<!ENTITY % patternAttrs "">
+
+<!-- Define some entities for informative use as attribute
+        types -->
+<!ENTITY % URIref "CDATA">
+<!ENTITY % XPathExpr "CDATA">
+<!ENTITY % QName "NMTOKEN">
+<!ENTITY % QNames "NMTOKENS">
+<!ENTITY % NCName "NMTOKEN">
+<!ENTITY % nonNegativeInteger "NMTOKEN">
+<!ENTITY % boolean "(true|false)">
+<!ENTITY % simpleDerivationSet "CDATA">
+<!--
+        #all or space-separated list drawn from derivationChoice
+  -->
+
+<!--
+        Note that the use of 'facet' below is less restrictive
+        than is really intended:  There should in fact be no
+        more than one of each of minInclusive, minExclusive,
+        maxInclusive, maxExclusive, totalDigits, fractionDigits,
+        length, maxLength, minLength within datatype,
+        and the min- and max- variants of Inclusive and Exclusive
+        are mutually exclusive. On the other hand,  pattern and
+        enumeration may repeat.
+  -->
+<!ENTITY % minBound "(%minInclusive; | %minExclusive;)">
+<!ENTITY % maxBound "(%maxInclusive; | %maxExclusive;)">
+<!ENTITY % bounds "%minBound; | %maxBound;">
+<!ENTITY % numeric "%totalDigits; | %fractionDigits;">
+<!ENTITY % ordered "%bounds; | %numeric;">
+<!ENTITY % unordered
+   "%pattern; | %enumeration; | %whiteSpace; | %length; |
+   %maxLength; | %minLength;">
+<!ENTITY % facet "%ordered; | %unordered;">
+<!ENTITY % facetAttr 
+        "value CDATA #REQUIRED
+        id ID #IMPLIED">
+<!ENTITY % fixedAttr "fixed %boolean; #IMPLIED">
+<!ENTITY % facetModel "(%annotation;)?">
+<!ELEMENT %simpleType;
+        ((%annotation;)?, (%restriction; | %list; | %union;))>
+<!ATTLIST %simpleType;
+    name      %NCName; #IMPLIED
+    final     %simpleDerivationSet; #IMPLIED
+    id        ID       #IMPLIED
+    %simpleTypeAttrs;>
+<!-- name is required at top level -->
+<!ELEMENT %restriction; ((%annotation;)?,
+                         (%restriction1; |
+                          ((%simpleType;)?,(%facet;)*)),
+                         (%attrDecls;))>
+<!ATTLIST %restriction;
+    base      %QName;                  #IMPLIED
+    id        ID       #IMPLIED
+    %restrictionAttrs;>
+<!--
+        base and simpleType child are mutually exclusive,
+        one is required.
+
+        restriction is shared between simpleType and
+        simpleContent and complexContent (in XMLSchema.xsd).
+        restriction1 is for the latter cases, when this
+        is restricting a complex type, as is attrDecls.
+  -->
+<!ELEMENT %list; ((%annotation;)?,(%simpleType;)?)>
+<!ATTLIST %list;
+    itemType      %QName;             #IMPLIED
+    id        ID       #IMPLIED
+    %listAttrs;>
+<!--
+        itemType and simpleType child are mutually exclusive,
+        one is required
+  -->
+<!ELEMENT %union; ((%annotation;)?,(%simpleType;)*)>
+<!ATTLIST %union;
+    id            ID       #IMPLIED
+    memberTypes   %QNames;            #IMPLIED
+    %unionAttrs;>
+<!--
+        At least one item in memberTypes or one simpleType
+        child is required
+  -->
+
+<!ELEMENT %maxExclusive; %facetModel;>
+<!ATTLIST %maxExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxExclusiveAttrs;>
+<!ELEMENT %minExclusive; %facetModel;>
+<!ATTLIST %minExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minExclusiveAttrs;>
+
+<!ELEMENT %maxInclusive; %facetModel;>
+<!ATTLIST %maxInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxInclusiveAttrs;>
+<!ELEMENT %minInclusive; %facetModel;>
+<!ATTLIST %minInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minInclusiveAttrs;>
+
+<!ELEMENT %totalDigits; %facetModel;>
+<!ATTLIST %totalDigits;
+        %facetAttr;
+        %fixedAttr;
+        %totalDigitsAttrs;>
+<!ELEMENT %fractionDigits; %facetModel;>
+<!ATTLIST %fractionDigits;
+        %facetAttr;
+        %fixedAttr;
+        %fractionDigitsAttrs;>
+
+<!ELEMENT %length; %facetModel;>
+<!ATTLIST %length;
+        %facetAttr;
+        %fixedAttr;
+        %lengthAttrs;>
+<!ELEMENT %minLength; %facetModel;>
+<!ATTLIST %minLength;
+        %facetAttr;
+        %fixedAttr;
+        %minLengthAttrs;>
+<!ELEMENT %maxLength; %facetModel;>
+<!ATTLIST %maxLength;
+        %facetAttr;
+        %fixedAttr;
+        %maxLengthAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %enumeration; %facetModel;>
+<!ATTLIST %enumeration;
+        %facetAttr;
+        %enumerationAttrs;>
+
+<!ELEMENT %whiteSpace; %facetModel;>
+<!ATTLIST %whiteSpace;
+        %facetAttr;
+        %fixedAttr;
+        %whiteSpaceAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %pattern; %facetModel;>
+<!ATTLIST %pattern;
+        %facetAttr;
+        %patternAttrs;>

--- a/src/test/resources/xsf/defaultSchema.xsd
+++ b/src/test/resources/xsf/defaultSchema.xsd
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema 
+	xmlns:xs='http://www.w3.org/2001/XMLSchema'
+	xmlns:exi='http://jabber.org/protocol/compress/exi'
+	targetNamespace='urn:xmpp:exi:default'
+	elementFormDefault='qualified'>
+	<xs:import namespace='http://etherx.jabber.org/streams' schemaLocation="streams.xsd"/>
+	<xs:import namespace='http://jabber.org/protocol/compress/exi' schemaLocation="xep-0322-01.xsd"/>
+</xs:schema>

--- a/src/test/resources/xsf/jabber-client.xsd
+++ b/src/test/resources/xsf/jabber-client.xsd
@@ -1,0 +1,216 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xml='http://www.w3.org/XML/1998/namespace'
+    targetNamespace='jabber:client'
+    xmlns='jabber:client'
+    elementFormDefault='qualified'>
+
+  <xs:import namespace='urn:ietf:params:xml:ns:xmpp-stanzas'
+             schemaLocation='http://xmpp.org/schemas/stanzaerror.xsd'/>
+  <xs:import namespace='http://www.w3.org/XML/1998/namespace'
+             schemaLocation='http://www.w3.org/2001/03/xml.xsd'/>
+
+  <xs:element name='message'>
+     <xs:complexType>
+        <xs:sequence>
+          <xs:choice minOccurs='0' maxOccurs='unbounded'>
+            <xs:element ref='subject'/>
+            <xs:element ref='body'/>
+            <xs:element ref='thread'/>
+          </xs:choice>
+          <xs:any     namespace='##other'
+                      minOccurs='0'
+                      maxOccurs='unbounded'
+                      processContents='lax'/>
+          <xs:element ref='error'
+                      minOccurs='0'/>
+        </xs:sequence>
+        <xs:attribute name='from'
+                      type='xs:string'
+                      use='optional'/>
+        <xs:attribute name='id'
+                      type='xs:NMTOKEN'
+                      use='optional'/>
+        <xs:attribute name='to'
+                      type='xs:string'
+                      use='optional'/>
+        <xs:attribute name='type' 
+                      use='optional' 
+                      default='normal'>
+          <xs:simpleType>
+            <xs:restriction base='xs:NMTOKEN'>
+              <xs:enumeration value='chat'/>
+              <xs:enumeration value='error'/>
+              <xs:enumeration value='groupchat'/>
+              <xs:enumeration value='headline'/>
+              <xs:enumeration value='normal'/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute ref='xml:lang' use='optional'/>
+     </xs:complexType>
+  </xs:element>
+
+  <xs:element name='body'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:string'>
+          <xs:attribute ref='xml:lang' use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='subject'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:string'>
+          <xs:attribute ref='xml:lang' use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='thread'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:NMTOKEN'>
+          <xs:attribute name='parent'
+                        type='xs:NMTOKEN'
+                        use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='presence'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs='0' maxOccurs='unbounded'>
+          <xs:element ref='show'/>
+          <xs:element ref='status'/>
+          <xs:element ref='priority'/>
+        </xs:choice>
+        <xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='unbounded'
+                    processContents='lax'/>
+        <xs:element ref='error'
+                    minOccurs='0'/>
+      </xs:sequence>
+      <xs:attribute name='from'
+                    type='xs:string'
+                    use='optional'/>
+      <xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='optional'/>
+      <xs:attribute name='to'
+                    type='xs:string'
+                    use='optional'/>
+      <xs:attribute name='type' use='optional'>
+        <xs:simpleType>
+          <xs:restriction base='xs:NMTOKEN'>
+            <xs:enumeration value='error'/>
+            <xs:enumeration value='probe'/>
+            <xs:enumeration value='subscribe'/>
+            <xs:enumeration value='subscribed'/>
+            <xs:enumeration value='unavailable'/>
+            <xs:enumeration value='unsubscribe'/>
+            <xs:enumeration value='unsubscribed'/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref='xml:lang' use='optional'/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='show'>
+    <xs:simpleType>
+      <xs:restriction base='xs:NMTOKEN'>
+        <xs:enumeration value='away'/>
+        <xs:enumeration value='chat'/>
+        <xs:enumeration value='dnd'/>
+        <xs:enumeration value='xa'/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+
+  <xs:element name='status'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='string1024'>
+          <xs:attribute ref='xml:lang' use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name='string1024'>
+    <xs:restriction base='xs:string'>
+      <xs:minLength value='1'/>
+      <xs:maxLength value='1024'/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name='priority' type='xs:byte'/>
+
+  <xs:element name='iq'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='1'
+                    processContents='lax'/>
+        <xs:element ref='error'
+                    minOccurs='0'/>
+      </xs:sequence>
+      <xs:attribute name='from'
+                    type='xs:string'
+                    use='optional'/>
+      <xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='required'/>
+      <xs:attribute name='to'
+                    type='xs:string'
+                    use='optional'/>
+      <xs:attribute name='type' use='required'>
+        <xs:simpleType>
+          <xs:restriction base='xs:NMTOKEN'>
+            <xs:enumeration value='error'/>
+            <xs:enumeration value='get'/>
+            <xs:enumeration value='result'/>
+            <xs:enumeration value='set'/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref='xml:lang' use='optional'/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='error'>
+    <xs:complexType>
+      <xs:sequence xmlns:err='urn:ietf:params:xml:ns:xmpp-stanzas'>
+        <xs:group ref='err:stanzaErrorGroup'/>
+        <xs:element ref='err:text'
+                    minOccurs='0'/>
+      </xs:sequence>
+      <xs:attribute name='by' 
+                    type='xs:string' 
+                    use='optional'/>
+      <xs:attribute name='type' use='required'>
+        <xs:simpleType>
+          <xs:restriction base='xs:NMTOKEN'>
+            <xs:enumeration value='auth'/>
+            <xs:enumeration value='cancel'/>
+            <xs:enumeration value='continue'/>
+            <xs:enumeration value='modify'/>
+            <xs:enumeration value='wait'/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/src/test/resources/xsf/jabber-server.xsd
+++ b/src/test/resources/xsf/jabber-server.xsd
@@ -1,0 +1,216 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xml='http://www.w3.org/XML/1998/namespace'
+    targetNamespace='jabber:server'
+    xmlns='jabber:server'
+    elementFormDefault='qualified'>
+
+  <xs:import namespace='urn:ietf:params:xml:ns:xmpp-stanzas'
+             schemaLocation='http://xmpp.org/schemas/stanzaerror.xsd'/>
+  <xs:import namespace='http://www.w3.org/XML/1998/namespace'
+             schemaLocation='http://www.w3.org/2001/03/xml.xsd'/>
+
+  <xs:element name='message'>
+     <xs:complexType>
+        <xs:sequence>
+          <xs:choice minOccurs='0' maxOccurs='unbounded'>
+            <xs:element ref='subject'/>
+            <xs:element ref='body'/>
+            <xs:element ref='thread'/>
+          </xs:choice>
+          <xs:any namespace='##other'
+                  minOccurs='0'
+                  maxOccurs='unbounded'
+                  processContents='lax'/>
+          <xs:element ref='error'
+                      minOccurs='0'/>
+        </xs:sequence>
+        <xs:attribute name='from'
+                      type='xs:string'
+                      use='required'/>
+        <xs:attribute name='id'
+                      type='xs:NMTOKEN'
+                      use='optional'/>
+        <xs:attribute name='to'
+                      type='xs:string'
+                      use='required'/>
+        <xs:attribute name='type' 
+                      use='optional' 
+                      default='normal'>
+          <xs:simpleType>
+            <xs:restriction base='xs:NMTOKEN'>
+              <xs:enumeration value='chat'/>
+              <xs:enumeration value='error'/>
+              <xs:enumeration value='groupchat'/>
+              <xs:enumeration value='headline'/>
+              <xs:enumeration value='normal'/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute ref='xml:lang' use='optional'/>
+     </xs:complexType>
+  </xs:element>
+
+  <xs:element name='body'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:string'>
+          <xs:attribute ref='xml:lang' use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='subject'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:string'>
+          <xs:attribute ref='xml:lang' use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='thread'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:NMTOKEN'>
+          <xs:attribute name='parent'
+                        type='xs:NMTOKEN'
+                        use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='presence'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs='0' maxOccurs='unbounded'>
+          <xs:element ref='show'/>
+          <xs:element ref='status'/>
+          <xs:element ref='priority'/>
+        </xs:choice>
+        <xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='unbounded'
+                    processContents='lax'/>
+        <xs:element ref='error'
+                    minOccurs='0'/>
+      </xs:sequence>
+      <xs:attribute name='from'
+                    type='xs:string'
+                    use='required'/>
+      <xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='optional'/>
+      <xs:attribute name='to'
+                    type='xs:string'
+                    use='required'/>
+      <xs:attribute name='type' use='optional'>
+        <xs:simpleType>
+          <xs:restriction base='xs:NMTOKEN'>
+            <xs:enumeration value='error'/>
+            <xs:enumeration value='probe'/>
+            <xs:enumeration value='subscribe'/>
+            <xs:enumeration value='subscribed'/>
+            <xs:enumeration value='unavailable'/>
+            <xs:enumeration value='unsubscribe'/>
+            <xs:enumeration value='unsubscribed'/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref='xml:lang' use='optional'/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='show'>
+    <xs:simpleType>
+      <xs:restriction base='xs:NMTOKEN'>
+        <xs:enumeration value='away'/>
+        <xs:enumeration value='chat'/>
+        <xs:enumeration value='dnd'/>
+        <xs:enumeration value='xa'/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+
+  <xs:element name='status'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='string1024'>
+          <xs:attribute ref='xml:lang' use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name='string1024'>
+    <xs:restriction base='xs:string'>
+      <xs:minLength value='1'/>
+      <xs:maxLength value='1024'/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name='priority' type='xs:byte' default='0'/>
+
+  <xs:element name='iq'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any namespace='##other'
+                minOccurs='0'
+                maxOccurs='1'
+                processContents='lax'/>
+        <xs:element ref='error'
+                    minOccurs='0'/>
+      </xs:sequence>
+      <xs:attribute name='from'
+                    type='xs:string'
+                    use='required'/>
+      <xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='required'/>
+      <xs:attribute name='to'
+                    type='xs:string'
+                    use='required'/>
+      <xs:attribute name='type' use='required'>
+        <xs:simpleType>
+          <xs:restriction base='xs:NMTOKEN'>
+            <xs:enumeration value='error'/>
+            <xs:enumeration value='get'/>
+            <xs:enumeration value='result'/>
+            <xs:enumeration value='set'/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref='xml:lang' use='optional'/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='error'>
+    <xs:complexType>
+      <xs:sequence xmlns:err='urn:ietf:params:xml:ns:xmpp-stanzas'>
+        <xs:group ref='err:stanzaErrorGroup'/>
+        <xs:element ref='err:text'
+                    minOccurs='0'/>
+      </xs:sequence>
+      <xs:attribute name='by' 
+                    type='xs:string' 
+                    use='optional'/>
+      <xs:attribute name='type' use='required'>
+        <xs:simpleType>
+          <xs:restriction base='xs:NMTOKEN'>
+            <xs:enumeration value='auth'/>
+            <xs:enumeration value='cancel'/>
+            <xs:enumeration value='continue'/>
+            <xs:enumeration value='modify'/>
+            <xs:enumeration value='wait'/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/src/test/resources/xsf/sasl.xsd
+++ b/src/test/resources/xsf/sasl.xsd
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xml='http://www.w3.org/XML/1998/namespace'
+    targetNamespace='urn:ietf:params:xml:ns:xmpp-sasl'
+    xmlns='urn:ietf:params:xml:ns:xmpp-sasl'
+    elementFormDefault='qualified'>
+
+  <xs:import namespace='http://www.w3.org/XML/1998/namespace'
+             schemaLocation='http://www.w3.org/2001/03/xml.xsd'/>
+
+  <xs:element name='mechanisms'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name='mechanism'
+                    minOccurs='1'
+                    maxOccurs='unbounded'
+                    type='xs:NMTOKEN'/>
+        <xs:any namespace='##other'
+                minOccurs='0'
+                maxOccurs='unbounded'
+                processContents='lax'/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='abort' type='empty'/>
+
+  <xs:element name='auth'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:string'>
+          <xs:attribute name='mechanism'
+                        type='xs:NMTOKEN'
+                        use='required'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='challenge' type='xs:string'/>
+
+  <xs:element name='response' type='xs:string'/>
+
+  <xs:element name='success' type='xs:string'/>
+
+  <xs:element name='failure'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs='0'>
+          <xs:element name='aborted' type='empty'/>
+          <xs:element name='account-disabled' type='empty'/>
+          <xs:element name='credentials-expired' type='empty'/>
+          <xs:element name='encryption-required' type='empty'/>
+          <xs:element name='incorrect-encoding' type='empty'/>
+          <xs:element name='invalid-authzid' type='empty'/>
+          <xs:element name='invalid-mechanism' type='empty'/>
+          <xs:element name='malformed-request' type='empty'/>
+          <xs:element name='mechanism-too-weak' type='empty'/>
+          <xs:element name='not-authorized' type='empty'/>
+          <xs:element name='temporary-auth-failure' type='empty'/>
+          <xs:element name='transition-needed' type='empty'/>
+        </xs:choice>
+        <xs:element ref='text' minOccurs='0' maxOccurs='1'/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='text'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:string'>
+          <xs:attribute ref='xml:lang' use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name='empty'>
+    <xs:restriction base='xs:string'>
+      <xs:enumeration value=''/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/src/test/resources/xsf/stanzaerror.xsd
+++ b/src/test/resources/xsf/stanzaerror.xsd
@@ -1,0 +1,81 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xml='http://www.w3.org/XML/1998/namespace'
+    targetNamespace='urn:ietf:params:xml:ns:xmpp-stanzas'
+    xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'
+    elementFormDefault='qualified'>
+
+  <xs:import namespace='http://www.w3.org/XML/1998/namespace'
+             schemaLocation='http://www.w3.org/2001/03/xml.xsd'/>
+
+  <xs:element name='bad-request' type='empty'/>
+  <xs:element name='conflict' type='empty'/>
+  <xs:element name='feature-not-implemented' type='empty'/>
+  <xs:element name='forbidden' type='empty'/>
+  <xs:element name='gone' type='xs:string'/>
+  <xs:element name='internal-server-error' type='empty'/>
+  <xs:element name='item-not-found' type='empty'/>
+  <xs:element name='jid-malformed' type='empty'/>
+  <xs:element name='not-acceptable' type='empty'/>
+  <xs:element name='not-allowed' type='empty'/>
+  <xs:element name='not-authorized' type='empty'/>
+  <xs:element name='payment-required' type='empty'/>
+  <xs:element name='policy-violation' type='empty'/>
+  <xs:element name='recipient-unavailable' type='empty'/>
+  <xs:element name='redirect' type='xs:string'/>
+  <xs:element name='registration-required' type='empty'/>
+  <xs:element name='remote-server-not-found' type='empty'/>
+  <xs:element name='remote-server-timeout' type='empty'/>
+  <xs:element name='resource-constraint' type='empty'/>
+  <xs:element name='service-unavailable' type='empty'/>
+  <xs:element name='subscription-required' type='empty'/>
+  <xs:element name='undefined-condition' type='empty'/>
+  <xs:element name='unexpected-request' type='empty'/>
+
+  <xs:group name='stanzaErrorGroup'>
+    <xs:choice>
+      <xs:element ref='bad-request'/>
+      <xs:element ref='conflict'/>
+      <xs:element ref='feature-not-implemented'/>
+      <xs:element ref='forbidden'/>
+      <xs:element ref='gone'/>
+      <xs:element ref='internal-server-error'/>
+      <xs:element ref='item-not-found'/>
+      <xs:element ref='jid-malformed'/>
+      <xs:element ref='not-acceptable'/>
+      <xs:element ref='not-authorized'/>
+      <xs:element ref='not-allowed'/>
+      <xs:element ref='payment-required'/>
+      <xs:element ref='policy-violation'/>
+      <xs:element ref='recipient-unavailable'/>
+      <xs:element ref='redirect'/>
+      <xs:element ref='registration-required'/>
+      <xs:element ref='remote-server-not-found'/>
+      <xs:element ref='remote-server-timeout'/>
+      <xs:element ref='resource-constraint'/>
+      <xs:element ref='service-unavailable'/>
+      <xs:element ref='subscription-required'/>
+      <xs:element ref='undefined-condition'/>
+      <xs:element ref='unexpected-request'/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:element name='text'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:string'>
+          <xs:attribute ref='xml:lang' use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name='empty'>
+    <xs:restriction base='xs:string'>
+      <xs:enumeration value=''/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/src/test/resources/xsf/streamerror.xsd
+++ b/src/test/resources/xsf/streamerror.xsd
@@ -1,0 +1,85 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xml='http://www.w3.org/XML/1998/namespace'
+    targetNamespace='urn:ietf:params:xml:ns:xmpp-streams'
+    xmlns='urn:ietf:params:xml:ns:xmpp-streams'
+    elementFormDefault='qualified'>
+
+  <xs:import namespace='http://www.w3.org/XML/1998/namespace'
+             schemaLocation='http://www.w3.org/2001/03/xml.xsd'/>
+
+  <xs:element name='bad-format' type='empty'/>
+  <xs:element name='bad-namespace-prefix' type='empty'/>
+  <xs:element name='conflict' type='empty'/>
+  <xs:element name='connection-timeout' type='empty'/>
+  <xs:element name='host-gone' type='empty'/>
+  <xs:element name='host-unknown' type='empty'/>
+  <xs:element name='improper-addressing' type='empty'/>
+  <xs:element name='internal-server-error' type='empty'/>
+  <xs:element name='invalid-from' type='empty'/>
+  <xs:element name='invalid-namespace' type='empty'/>
+  <xs:element name='invalid-xml' type='empty'/>
+  <xs:element name='not-authorized' type='empty'/>
+  <xs:element name='not-well-formed' type='empty'/>
+  <xs:element name='policy-violation' type='empty'/>
+  <xs:element name='remote-connection-failed' type='empty'/>
+  <xs:element name='reset' type='empty'/>
+  <xs:element name='resource-constraint' type='empty'/>
+  <xs:element name='restricted-xml' type='empty'/>
+  <xs:element name='see-other-host' type='xs:string'/>
+  <xs:element name='system-shutdown' type='empty'/>
+  <xs:element name='undefined-condition' type='empty'/>
+  <xs:element name='unsupported-encoding' type='empty'/>
+  <xs:element name='unsupported-feature' type='empty'/>
+  <xs:element name='unsupported-stanza-type' type='empty'/>
+  <xs:element name='unsupported-version' type='empty'/>
+
+  <xs:group name='streamErrorGroup'>
+    <xs:choice>
+      <xs:element ref='bad-format'/>
+      <xs:element ref='bad-namespace-prefix'/>
+      <xs:element ref='conflict'/>
+      <xs:element ref='connection-timeout'/>
+      <xs:element ref='host-gone'/>
+      <xs:element ref='host-unknown'/>
+      <xs:element ref='improper-addressing'/>
+      <xs:element ref='internal-server-error'/>
+      <xs:element ref='invalid-from'/>
+      <xs:element ref='invalid-namespace'/>
+      <xs:element ref='invalid-xml'/>
+      <xs:element ref='not-authorized'/>
+      <xs:element ref='not-well-formed'/>
+      <xs:element ref='policy-violation'/>
+      <xs:element ref='remote-connection-failed'/>
+      <xs:element ref='reset'/>
+      <xs:element ref='resource-constraint'/>
+      <xs:element ref='restricted-xml'/>
+      <xs:element ref='see-other-host'/>
+      <xs:element ref='system-shutdown'/>
+      <xs:element ref='undefined-condition'/>
+      <xs:element ref='unsupported-encoding'/>
+      <xs:element ref='unsupported-feature'/>
+      <xs:element ref='unsupported-stanza-type'/>
+      <xs:element ref='unsupported-version'/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:element name='text'>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base='xs:string'>
+          <xs:attribute ref='xml:lang' use='optional'/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name='empty'>
+    <xs:restriction base='xs:string'>
+      <xs:enumeration value=''/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/src/test/resources/xsf/streams.xsd
+++ b/src/test/resources/xsf/streams.xsd
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xml='http://www.w3.org/XML/1998/namespace'
+    targetNamespace='http://etherx.jabber.org/streams'
+    xmlns='http://etherx.jabber.org/streams'
+    elementFormDefault='unqualified'>
+
+  <xs:import namespace='jabber:client'
+             schemaLocation='http://xmpp.org/schemas/jabber-client.xsd'/>
+  <xs:import namespace='jabber:server'
+             schemaLocation='http://xmpp.org/schemas/jabber-server.xsd'/>
+  <xs:import namespace='urn:ietf:params:xml:ns:xmpp-sasl'
+             schemaLocation='http://xmpp.org/schemas/sasl.xsd'/>
+  <xs:import namespace='urn:ietf:params:xml:ns:xmpp-streams'
+             schemaLocation='http://xmpp.org/schemas/streamerror.xsd'/>
+  <xs:import namespace='urn:ietf:params:xml:ns:xmpp-tls'
+             schemaLocation='http://xmpp.org/schemas/tls.xsd'/>
+  <xs:import namespace='http://www.w3.org/XML/1998/namespace'
+             schemaLocation='http://www.w3.org/2001/03/xml.xsd'/>
+
+  <xs:element name='stream'>
+    <xs:complexType>
+      <xs:sequence xmlns:client='jabber:client'
+                   xmlns:server='jabber:server'>
+        <xs:element ref='features' 
+                    minOccurs='0' 
+                    maxOccurs='1'/>
+        <xs:any namespace='urn:ietf:params:xml:ns:xmpp-tls'
+                minOccurs='0'
+                maxOccurs='1'/>
+        <xs:any namespace='urn:ietf:params:xml:ns:xmpp-sasl'
+                minOccurs='0'
+                maxOccurs='1'/>
+        <xs:any namespace='##other'
+                minOccurs='0'
+                maxOccurs='unbounded'
+                processContents='lax'/>
+        <xs:choice minOccurs='0' maxOccurs='1'>
+          <xs:choice minOccurs='0' maxOccurs='unbounded'>
+            <xs:element ref='client:message'/>
+            <xs:element ref='client:presence'/>
+            <xs:element ref='client:iq'/>
+          </xs:choice>
+          <xs:choice minOccurs='0' maxOccurs='unbounded'>
+            <xs:element ref='server:message'/>
+            <xs:element ref='server:presence'/>
+            <xs:element ref='server:iq'/>
+          </xs:choice>
+        </xs:choice>
+        <xs:element ref='error' minOccurs='0' maxOccurs='1'/>
+      </xs:sequence>
+      <xs:attribute name='from' type='xs:string' use='optional'/>
+      <xs:attribute name='id' type='xs:string' use='optional'/>
+      <xs:attribute name='to' type='xs:string' use='optional'/>
+      <xs:attribute name='version' type='xs:decimal' use='optional'/>
+      <xs:attribute ref='xml:lang' use='optional'/>
+      <xs:anyAttribute namespace='##other' processContents='lax'/> 
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='features'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any namespace='##other'
+                minOccurs='0'
+                maxOccurs='unbounded'
+                processContents='lax'/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='error'>
+    <xs:complexType>
+      <xs:sequence  xmlns:err='urn:ietf:params:xml:ns:xmpp-streams'>
+        <xs:group   ref='err:streamErrorGroup'/>
+        <xs:element ref='err:text'
+                    minOccurs='0'
+                    maxOccurs='1'/>
+        <xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='1'
+                    processContents='lax'/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/src/test/resources/xsf/tls.xsd
+++ b/src/test/resources/xsf/tls.xsd
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='urn:ietf:params:xml:ns:xmpp-tls'
+    xmlns='urn:ietf:params:xml:ns:xmpp-tls'
+    elementFormDefault='qualified'>
+
+  <xs:element name='starttls'>
+    <xs:complexType>
+      <xs:choice minOccurs='0' maxOccurs='1'>
+        <xs:element name='required' type='empty'/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name='proceed' type='empty'/>
+
+  <xs:element name='failure' type='empty'/>
+
+  <xs:simpleType name='empty'>
+    <xs:restriction base='xs:string'>
+      <xs:enumeration value=''/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/src/test/resources/xsf/xep-0322-01.xsd
+++ b/src/test/resources/xsf/xep-0322-01.xsd
@@ -1,0 +1,243 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/compress/exi'
+    xmlns='http://jabber.org/protocol/compress/exi'
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:client='jabber:client'
+    xmlns:streams='http://etherx.jabber.org/streams'
+    elementFormDefault='qualified'>
+    
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xs:import namespace="http://etherx.jabber.org/streams"/>
+    
+    <xs:element name='setup' type='Setup'/>
+    <xs:element name='setupResponse' type='SetupResponse'/>
+
+    <xs:complexType name='Setup'>
+        <xs:choice minOccurs='0' maxOccurs='unbounded'>
+            <xs:element name='schema' type='Schema'/>
+            <xs:element name='datatypeRepresentationMap' type='DatatypeRepresentationMap'/>
+        </xs:choice>
+        <xs:attributeGroup ref='Options'/>
+    <xs:attribute name='configurationId' type='xs:string' use='optional'/>
+    <xs:attribute name='configurationLocation' type='xs:string' use='optional'/>
+    </xs:complexType>
+
+    <xs:complexType name='SetupResponse'>
+        <xs:choice minOccurs='0' maxOccurs='unbounded'>
+            <xs:element name='schema' type='Schema'/>
+            <xs:element name='datatypeRepresentationMap' type='DatatypeRepresentationMap'/>
+        <xs:element name='missingSchema' type='Schema'/>
+        </xs:choice>
+        <xs:attributeGroup ref='Options'/>
+    <xs:attribute name='configurationId' type='xs:string' use='optional'/>
+    <xs:attribute name='configurationLocation' type='xs:string' use='optional'/>
+    <xs:attribute name='agreement' type='xs:boolean' use='optional' default='false'/>
+    </xs:complexType>
+    
+    <xs:complexType name='Schema'>
+        <xs:attribute name='ns' type='xs:string' use='required'/>
+        <xs:attribute name='bytes' type='xs:positiveInteger' use='required'/>
+        <xs:attribute name='md5Hash' type='MD5Hash' use='required'/>
+    </xs:complexType>
+    
+    <xs:complexType name='DatatypeRepresentationMap'>
+        <xs:attribute name='type' type='xs:string' use='required'/>
+        <xs:attribute name='representAs' type='xs:string' use='required'/>
+    </xs:complexType>
+    
+    <xs:attributeGroup name='Options'>
+        <xs:attribute name='version' type='xs:positiveInteger' use='optional' default='1'/>
+        <xs:attribute name='alignment' type='Alignment' use='optional' default='bit-packed'>
+            <xs:annotation>
+                <xs:documentation>The alignment option is used to control the alignment of event codes and content items. The value is one of bit-packed, byte-alignment or pre-compression, of which bit-packed is the default value assumed when the "alignment" element is absent in the EXI Options document. The option values byte-alignment and pre-compression are effected when "byte" and "pre-compress" elements are present in the EXI Options document, respectively. When the value of compression option is set to true, alignment of the EXI Body is governed by the rules specified in 9. EXI Compression instead of the alignment option value. The "alignment" element MUST NOT appear in an EXI options document when the "compression" element is present.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='compression' type='xs:boolean' use='optional' default='false'>
+            <xs:annotation>
+                <xs:documentation>The compression option is a Boolean used to increase compactness using additional computational resources. The default value "false" is assumed when the "compression" element is absent in the EXI Options document whereas its presence denotes the value "true". When set to true, the event codes and associated content are compressed according to 9. EXI Compression regardless of the alignment option value. As mentioned above, the "compression" element MUST NOT appear in an EXI options document when the "alignment" element is present.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='strict' type='xs:boolean' use='optional' default='false'>
+            <xs:annotation>
+                <xs:documentation>The strict option is a Boolean used to increase compactness by using a strict interpretation of the schemas and omitting preservation of certain items, such as comments, processing instructions and namespace prefixes. The default value "false" is assumed when the "strict" element is absent in the EXI Options document whereas its presence denotes the value "true". When set to true, those productions that have NS, CM, PI, ER, and SC terminal symbols are omitted from the EXI grammars, and schema-informed element and type grammars are restricted to only permit items declared in the schemas. A note in section 8.5.4.4.2 Adding Productions when Strict is True describes some additional restrictions consequential of the use of this option. The "strict" element MUST NOT appear in an EXI options document when one of "dtd", "prefixes", "comments", "pis" or "selfContained" element is present in the same options document.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='preserveComments' type='xs:boolean' use='optional' default='false'>
+            <xs:annotation>
+                <xs:documentation>Comments are preserved. Must not be used together with the strict option.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='preservePIs' type='xs:boolean' use='optional' default='false'>
+            <xs:annotation>
+                <xs:documentation>Processing instructions are preserved. Must not be used together with the strict option.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='preserveDTD' type='xs:boolean' use='optional' default='false'>
+            <xs:annotation>
+                <xs:documentation>DTD is preserved. Must not be used together with the strict option.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='preservePrefixes' type='xs:boolean' use='optional' default='false'>
+            <xs:annotation>
+                <xs:documentation>Prefixes are preserved. Must not be used together with the strict option.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='preserveLexical' type='xs:boolean' use='optional' default='false'>
+            <xs:annotation>
+                <xs:documentation>Lexical form of element and attribute values can be preserved in value content items. Can be used together with the strict option.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='selfContained' type='xs:boolean' use='optional' default='false'>
+            <xs:annotation>
+                <xs:documentation>The selfContained option is a Boolean used to enable the use of self-contained elements in the EXI stream. Self-contained elements may be read independently from the rest of the EXI body, allowing them to be indexed for random access. The "selfContained" element MUST NOT appear in an EXI options document when one of "compression", "pre-compression" or "strict" elements are present in the same options document. The default value "false" is assumed when the "selfContained" element is absent from the EXI Options document whereas its presence denotes the value "true".</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='blockSize' type='xs:positiveInteger' use='optional' default='1000000'>
+            <xs:annotation>
+                <xs:documentation>The blockSize option specifies the block size used for EXI compression. When the "blockSize" element is absent in the EXI Options document, the default blocksize of 1,000,000 is used. The default blockSize is intentionally large but can be reduced for processing large documents on devices with limited memory.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='valueMaxLength' type='xs:positiveInteger' use='optional'>
+            <xs:annotation>
+                <xs:documentation>The valueMaxLength option specifies the maximum length of value content items to be considered for addition to the string table. The default value "unbounded" is assumed when the "valueMaxLength" element is absent in the EXI Options document.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='valuePartitionCapacity' type='xs:positiveInteger' use='optional'>
+            <xs:annotation>
+                <xs:documentation>The valuePartitionCapacity option specifies the maximum number of value content items in the string table at any given time. The default value "unbounded" is assumed when the "valuePartitionCapacity" element is absent in the EXI Options document. Section 7.3.3 Partitions Optimized for Frequent use of String Literals specifies the behavior of the string table when this capacity is reached.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    <xs:attribute name='sessionWideBuffers' type='xs:boolean' use='optional' default='false'>
+        <xs:annotation>
+        <xs:documentation>If set to true, all buffers, string tables, etc. will be maintained during the entire session. This may improve performance during time since strings
+        can be omitted in the compressed binary stream, but it might also in some cases degrade performance since more options are available in the tables, requiring more bits 
+        to encode strings. The default value is false, meaning that buffers, string tables, etc., are cleared between each stanza.</xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    </xs:attributeGroup>
+    
+    <xs:simpleType name='MD5Hash'>
+        <xs:restriction base='xs:string'>
+            <xs:pattern value='[0-9a-f]{32}'/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:simpleType name='Alignment'>
+        <xs:restriction base='xs:string'>
+            <xs:enumeration value='bit-packed'>
+                <xs:annotation>
+                    <xs:documentation>The alignment option value bit-packed indicates that the event codes and associated content are packed in bits without any padding in-between.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value='byte-alignment'>
+                <xs:annotation>
+                    <xs:documentation>The alignment option value byte-alignment indicates that the event codes and associated content are aligned on byte boundaries. While byte-alignment generally results in EXI streams of larger sizes compared with their bit-packed equivalents, byte-alignment may provide a help in some use cases that involve frequent copying of large arrays of scalar data directly out of the stream. It can also make it possible to work with data in-place and can make it easier to debug encoded data by allowing items on aligned boundaries to be easily located in the stream.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value='pre-compression'>
+                <xs:annotation>
+                    <xs:documentation>The alignment option value pre-compression indicates that all steps involved in compression (see section 9. EXI Compression) are to be done with the exception of the final step of applying the DEFLATE algorithm. The primary use case of pre-compression is to avoid a duplicate compression step when compression capability is built into the transport protocol. In this case, pre-compression just prepares the stream for later compression.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:element name='uploadSchema'>
+    <xs:complexType>
+        <xs:simpleContent>
+        <xs:extension base='xs:base64Binary'>
+            <xs:attribute name='contentType' type='ContentType' use='optional' default='Text'/>
+            <xs:attribute name='bytes' type='xs:positiveInteger' use='optional'/>
+            <xs:attribute name='md5Hash' type='MD5Hash' use='optional'/>
+        </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    </xs:element>
+    
+    <xs:simpleType name='ContentType'>
+    <xs:restriction base='xs:string'>
+        <xs:enumeration value='Text'/>
+        <xs:enumeration value='ExiBody'/>
+        <xs:enumeration value='ExiDocument'/>
+    </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:element name='downloadSchema' type='DownloadSchema'/>
+    <xs:element name='downloadSchemaResponse' type='DownloadSchemaResponse'/>
+
+    <xs:complexType name='DownloadSchema'>
+        <xs:attribute name='url' type='xs:string' use='required'/>
+    </xs:complexType>
+    
+    <xs:complexType name='DownloadSchemaResponse'>
+        <xs:complexContent>
+            <xs:extension base='DownloadSchema'>
+        <xs:choice minOccurs='0' maxOccurs='1'>
+            <xs:element name='httpError'>
+            <xs:complexType>
+                <xs:attribute name='code' type='xs:positiveInteger' use='required'/>
+                <xs:attribute name='message' type='xs:string' use='required'/>
+            </xs:complexType>
+            </xs:element>
+            <xs:element name='invalidUrl'>
+            <xs:complexType>
+                <xs:attribute name='message' type='xs:string' use='required'/>
+            </xs:complexType>
+            </xs:element>
+            <xs:element name='timeout'>
+            <xs:complexType>
+                <xs:attribute name='message' type='xs:string' use='required'/>
+            </xs:complexType>
+            </xs:element>
+            <xs:element name='invalidContentType'>
+            <xs:complexType>
+                <xs:attribute name='contentTypeReturned' type='xs:string' use='required'/>
+            </xs:complexType>
+            </xs:element>
+            <xs:element name='error'>
+            <xs:complexType>
+                <xs:attribute name='message' type='xs:string' use='required'/>
+            </xs:complexType>
+            </xs:element>
+        </xs:choice>
+                <xs:attribute name='result' type='xs:boolean' use='required'/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    
+    <xs:element name='open'>
+    <xs:complexType>
+        <xs:sequence>
+        <xs:element name='xmlns' minOccurs='0' maxOccurs='unbounded'>
+            <xs:complexType>
+            <xs:attribute name='prefix' type='xs:string' use='required'/>
+            <xs:attribute name='namespace' type='xs:string' use='required'/>
+            </xs:complexType>
+        </xs:element>
+        <xs:element ref='streams:features'
+                minOccurs='0'
+                maxOccurs='1'/>
+        <xs:any namespace='urn:ietf:params:xml:ns:xmpp-tls'
+            minOccurs='0'
+            maxOccurs='1'/>
+        <xs:any namespace='urn:ietf:params:xml:ns:xmpp-sasl'
+            minOccurs='0'
+            maxOccurs='1'/>
+        <xs:element ref='streams:error' minOccurs='0' maxOccurs='1'/>
+        </xs:sequence>
+        <xs:attribute name='from' type='xs:string' use='optional'/>
+        <xs:attribute name='id' type='xs:string' use='optional'/>
+        <xs:attribute name='to' type='xs:string' use='optional'/>
+        <xs:attribute name='version' type='xs:decimal' use='optional'/>
+        <xs:attribute ref='xml:lang' use='optional'/>
+        <xs:anyAttribute namespace='##other' processContents='lax'/>
+    </xs:complexType>
+    </xs:element>
+    
+    <xs:element name='streamEnd'>
+    <xs:complexType/>
+    </xs:element>
+    
+</xs:schema>

--- a/src/test/resources/xsf/xml.xsd
+++ b/src/test/resources/xsf/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns   ="http://www.w3.org/1999/xhtml"
+           xml:lang="en">
+
+    <xs:annotation>
+        <xs:documentation>
+            <div>
+                <h1>About the XML namespace</h1>
+
+                <div class="bodytext">
+                    <p>
+                        This schema document describes the XML namespace, in a form
+                        suitable for import by other schema documents.
+                    </p>
+                    <p>
+                        See <a href="http://www.w3.org/XML/1998/namespace.html">
+                        http://www.w3.org/XML/1998/namespace.html</a> and
+                        <a href="http://www.w3.org/TR/REC-xml">
+                            http://www.w3.org/TR/REC-xml</a> for information
+                        about this namespace.
+                    </p>
+                    <p>
+                        Note that local names in this namespace are intended to be
+                        defined only by the World Wide Web Consortium or its subgroups.
+                        The names currently defined in this namespace are listed below.
+                        They should not be used with conflicting semantics by any Working
+                        Group, specification, or document instance.
+                    </p>
+                    <p>
+                        See further below in this document for more information about <a
+                            href="#usage">how to refer to this schema document from your own
+                        XSD schema documents</a> and about <a href="#nsversioning">the
+                        namespace-versioning policy governing this schema document</a>.
+                    </p>
+                </div>
+            </div>
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:attribute name="lang">
+        <xs:annotation>
+            <xs:documentation>
+                <div>
+
+                    <h3>lang (as an attribute name)</h3>
+                    <p>
+                        denotes an attribute whose value
+                        is a language code for the natural language of the content of
+                        any element; its value is inherited.  This name is reserved
+                        by virtue of its definition in the XML specification.</p>
+
+                </div>
+                <div>
+                    <h4>Notes</h4>
+                    <p>
+                        Attempting to install the relevant ISO 2- and 3-letter
+                        codes as the enumerated possible values is probably never
+                        going to be a realistic possibility.
+                    </p>
+                    <p>
+                        See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+                        http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+                        and the IANA language subtag registry at
+                        <a href="http://www.iana.org/assignments/language-subtag-registry">
+                            http://www.iana.org/assignments/language-subtag-registry</a>
+                        for further information.
+                    </p>
+                    <p>
+                        The union allows for the 'un-declaration' of xml:lang with
+                        the empty string.
+                    </p>
+                </div>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+            <xs:union memberTypes="xs:language">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value=""/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:attribute>
+
+    <xs:attribute name="space">
+        <xs:annotation>
+            <xs:documentation>
+                <div>
+
+                    <h3>space (as an attribute name)</h3>
+                    <p>
+                        denotes an attribute whose
+                        value is a keyword indicating what whitespace processing
+                        discipline is intended for the content of the element; its
+                        value is inherited.  This name is reserved by virtue of its
+                        definition in the XML specification.</p>
+
+                </div>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+            <xs:restriction base="xs:NCName">
+                <xs:enumeration value="default"/>
+                <xs:enumeration value="preserve"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:attribute>
+
+    <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+        <xs:documentation>
+            <div>
+
+                <h3>base (as an attribute name)</h3>
+                <p>
+                    denotes an attribute whose value
+                    provides a URI to be used as the base for interpreting any
+                    relative URIs in the scope of the element on which it
+                    appears; its value is inherited.  This name is reserved
+                    by virtue of its definition in the XML Base specification.</p>
+
+                <p>
+                    See <a
+                        href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+                    for information about this attribute.
+                </p>
+            </div>
+        </xs:documentation>
+    </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="id" type="xs:ID">
+        <xs:annotation>
+            <xs:documentation>
+                <div>
+
+                    <h3>id (as an attribute name)</h3>
+                    <p>
+                        denotes an attribute whose value
+                        should be interpreted as if declared to be of type ID.
+                        This name is reserved by virtue of its definition in the
+                        xml:id specification.</p>
+
+                    <p>
+                        See <a
+                            href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+                        for information about this attribute.
+                    </p>
+                </div>
+            </xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+
+    <xs:attributeGroup name="specialAttrs">
+        <xs:attribute ref="xml:base"/>
+        <xs:attribute ref="xml:lang"/>
+        <xs:attribute ref="xml:space"/>
+        <xs:attribute ref="xml:id"/>
+    </xs:attributeGroup>
+
+    <xs:annotation>
+        <xs:documentation>
+            <div>
+
+                <h3>Father (in any context at all)</h3>
+
+                <div class="bodytext">
+                    <p>
+                        denotes Jon Bosak, the chair of
+                        the original XML Working Group.  This name is reserved by
+                        the following decision of the W3C XML Plenary and
+                        XML Coordination groups:
+                    </p>
+                    <blockquote>
+                        <p>
+                            In appreciation for his vision, leadership and
+                            dedication the W3C XML Plenary on this 10th day of
+                            February, 2000, reserves for Jon Bosak in perpetuity
+                            the XML name "xml:Father".
+                        </p>
+                    </blockquote>
+                </div>
+            </div>
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:annotation>
+        <xs:documentation>
+            <div xml:id="usage" id="usage">
+                <h2><a name="usage">About this schema document</a></h2>
+
+                <div class="bodytext">
+                    <p>
+                        This schema defines attributes and an attribute group suitable
+                        for use by schemas wishing to allow <code>xml:base</code>,
+                        <code>xml:lang</code>, <code>xml:space</code> or
+                        <code>xml:id</code> attributes on elements they define.
+                    </p>
+                    <p>
+                        To enable this, such a schema must import this schema for
+                        the XML namespace, e.g. as follows:
+                    </p>
+                    <pre>
+                        &lt;schema . . .>
+                        . . .
+                        &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                        schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+                    </pre>
+                    <p>
+                        or
+                    </p>
+                    <pre>
+                        &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                        schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+                    </pre>
+                    <p>
+                        Subsequently, qualified reference to any of the attributes or the
+                        group defined below will have the desired effect, e.g.
+                    </p>
+                    <pre>
+                        &lt;type . . .>
+                        . . .
+                        &lt;attributeGroup ref="xml:specialAttrs"/>
+                    </pre>
+                    <p>
+                        will define a type which will schema-validate an instance element
+                        with any of those attributes.
+                    </p>
+                </div>
+            </div>
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:annotation>
+        <xs:documentation>
+            <div id="nsversioning" xml:id="nsversioning">
+                <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+                <div class="bodytext">
+                    <p>
+                        In keeping with the XML Schema WG's standard versioning
+                        policy, this schema document will persist at
+                        <a href="http://www.w3.org/2009/01/xml.xsd">
+                            http://www.w3.org/2009/01/xml.xsd</a>.
+                    </p>
+                    <p>
+                        At the date of issue it can also be found at
+                        <a href="http://www.w3.org/2001/xml.xsd">
+                            http://www.w3.org/2001/xml.xsd</a>.
+                    </p>
+                    <p>
+                        The schema document at that URI may however change in the future,
+                        in order to remain compatible with the latest version of XML
+                        Schema itself, or with the XML namespace itself.  In other words,
+                        if the XML Schema or XML namespaces change, the version of this
+                        document at <a href="http://www.w3.org/2001/xml.xsd">
+                        http://www.w3.org/2001/xml.xsd
+                    </a>
+                        will change accordingly; the version at
+                        <a href="http://www.w3.org/2009/01/xml.xsd">
+                            http://www.w3.org/2009/01/xml.xsd
+                        </a>
+                        will not change.
+                    </p>
+                    <p>
+                        Previous dated (and unchanging) versions of this schema
+                        document are at:
+                    </p>
+                    <ul>
+                        <li><a href="http://www.w3.org/2009/01/xml.xsd">
+                            http://www.w3.org/2009/01/xml.xsd</a></li>
+                        <li><a href="http://www.w3.org/2007/08/xml.xsd">
+                            http://www.w3.org/2007/08/xml.xsd</a></li>
+                        <li><a href="http://www.w3.org/2004/10/xml.xsd">
+                            http://www.w3.org/2004/10/xml.xsd</a></li>
+                        <li><a href="http://www.w3.org/2001/03/xml.xsd">
+                            http://www.w3.org/2001/03/xml.xsd</a></li>
+                    </ul>
+                </div>
+            </div>
+        </xs:documentation>
+    </xs:annotation>
+
+</xs:schema>
+


### PR DESCRIPTION
When creating grammar from a set of XSDs provided by the XMPP Standards Foundation, `com.siemens.ct.exi.grammars.EXIContentModelBuilder.handleStateEntries()` throws an AssertionError (when assertions are enabled in the VM), with the latest state of the code (v1.0.4 and 1.0.5-SNAPSHOT).

This PR adds a unit test that reproduces this behavior. 

The assertion that fails is: https://github.com/EXIficient/exificient-grammars/blob/77413b7978c2b6fa4a97ab0c3debb16f12d2712f/src/main/java/com/siemens/ct/exi/grammars/EXIContentModelBuilder.java#L378

The stack trace for the error is:
```java
java.lang.AssertionError
	at com.siemens.ct.exi.grammars.EXIContentModelBuilder.handleStateEntries(EXIContentModelBuilder.java:378)
	at com.siemens.ct.exi.grammars.EXIContentModelBuilder.handleStateEntries(EXIContentModelBuilder.java:484)
	at com.siemens.ct.exi.grammars.EXIContentModelBuilder.handleStateEntries(EXIContentModelBuilder.java:484)
	at com.siemens.ct.exi.grammars.EXIContentModelBuilder.handleStateEntries(EXIContentModelBuilder.java:414)
	at com.siemens.ct.exi.grammars.EXIContentModelBuilder.handleParticle(EXIContentModelBuilder.java:342)
	at com.siemens.ct.exi.grammars.XSDGrammarsBuilder.translateComplexTypeDefinitionToFSA(XSDGrammarsBuilder.java:1687)
	at com.siemens.ct.exi.grammars.XSDGrammarsBuilder.translateTypeDefinitionToFSA(XSDGrammarsBuilder.java:1613)
	at com.siemens.ct.exi.grammars.XSDGrammarsBuilder.translatElementDeclarationToFSA(XSDGrammarsBuilder.java:1472)
	at com.siemens.ct.exi.grammars.XSDGrammarsBuilder.toGrammars(XSDGrammarsBuilder.java:993)
	at com.siemens.ct.exi.grammars.GrammarFactory.createGrammars(GrammarFactory.java:91)
	at com.siemens.ct.exi.grammars.GrammarXSFTest.testAssertionNotThrown(GrammarXSFTest.java:49)
	<28 internal lines>
```

I am unsure if this is a problem in Exificient, the XSDs that are used, or the test setup. However, I am unable to progress further on this issue, and am looking for feedback from more capable eyes.